### PR TITLE
"find" no more!

### DIFF
--- a/mcdreforged/api/decorator/new_thread.py
+++ b/mcdreforged/api/decorator/new_thread.py
@@ -20,7 +20,7 @@ def new_thread(thread_name: Optional[str or Callable] = None):
 			return thread
 		# bring the signature of the func to the wrap function
 		# so inspect.getfullargspec(func) works correctly
-		# https://stackoverflow.com/questions/39926567find/python-create-decorator-preserving-function-arguments
+		# https://stackoverflow.com/questions/39926567/python-create-decorator-preserving-function-arguments
 		wrap.__signature__ = inspect.signature(func)
 		return wrap
 	# Directly use @on_new_thread without ending brackets case
@@ -43,7 +43,7 @@ def test():
 		time.sleep(0.5)
 		print(threading.current_thread().getName() + ' ' + str(value))
 
-	@new_thread('awa')
+	@new_thread('awa_shenjack')
 	def bla3(value):
 		time.sleep(0.5)
 		print(threading.current_thread().getName() + ' ' + str(value))

--- a/mcdreforged/api/decorator/new_thread.py
+++ b/mcdreforged/api/decorator/new_thread.py
@@ -43,7 +43,7 @@ def test():
 		time.sleep(0.5)
 		print(threading.current_thread().getName() + ' ' + str(value))
 
-	@new_thread('awa_shenjack')
+	@new_thread('awa')
 	def bla3(value):
 		time.sleep(0.5)
 		print(threading.current_thread().getName() + ' ' + str(value))


### PR DESCRIPTION
link should have no "find" in the middle
stackoverflow的链接中间多了个“find”