### PR TITLE
符合 Markdownlint 的 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-MCDReforged
---------
+# MCDReforged
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
 [![PyPI Version](https://img.shields.io/pypi/v/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
@@ -34,7 +33,7 @@ Since the console output of a Minecraft server has a stable format and contains 
 
 With the help of Minecraft command system, MCDR can send Minecraft commands via the standard input stream to affect the actual Minecraft server
 
-That's it, you can even think of MCDR as a robot that stares at the server console and can quickly respond to server output and input related commands if you like 
+That's it, you can even think of MCDR as a robot that stares at the server console and can quickly respond to server output and input related commands if you like
 
 ## Plugin
 
@@ -42,4 +41,4 @@ That's it, you can even think of MCDR as a robot that stares at the server conso
 
 ## Document
 
-Check https://mcdreforged.readthedocs.io/ for more details of MCDR
+Check <https://mcdreforged.readthedocs.io/> for more details of MCDR

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# MCDReforged
+MCDReforged
+===========
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
 [![PyPI Version](https://img.shields.io/pypi/v/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
@@ -19,13 +20,15 @@ Great thanks to chino_desu and his [MCDaemon 1.0](https://github.com/kafuuchino-
 
 Contact me on discord: `Fallen_Breath#1215`
 
-## Advantage
+Advantage
+---------
 
 - It's running above the server. It doesn't need to modify the server at all which keep everything vanilla
 - Hot-reloadable plugin system. You don't need to shut down the server to update the plugins
 - Multi platform / server compatibility. Supports vanilla, paper, bungeecord etc. on Linux / Windows
 
-## How it works?
+How it works?
+-------------
 
 MCDR uses [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) to start the server as a sub-process, then it has the ability to control the standard input / out stream of the server
 
@@ -35,10 +38,12 @@ With the help of Minecraft command system, MCDR can send Minecraft commands via 
 
 That's it, you can even think of MCDR as a robot that stares at the server console and can quickly respond to server output and input related commands if you like
 
-## Plugin
+Plugin
+------
 
 [Here](https://github.com/MCDReforged/PluginCatalogue) is a MCDR plugin collection repository
 
-## Document
+Document
+--------
 
 Check <https://mcdreforged.readthedocs.io/> for more details of MCDR

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-MCDReforged
-===========
+# MCDReforged
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
 [![PyPI Version](https://img.shields.io/pypi/v/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
@@ -20,15 +19,13 @@ Great thanks to chino_desu and his [MCDaemon 1.0](https://github.com/kafuuchino-
 
 Contact me on discord: `Fallen_Breath#1215`
 
-Advantage
----------
+## Advantage
 
 - It's running above the server. It doesn't need to modify the server at all which keep everything vanilla
 - Hot-reloadable plugin system. You don't need to shut down the server to update the plugins
 - Multi platform / server compatibility. Supports vanilla, paper, bungeecord etc. on Linux / Windows
 
-How it works?
--------------
+## How it works?
 
 MCDR uses [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) to start the server as a sub-process, then it has the ability to control the standard input / out stream of the server
 
@@ -38,12 +35,10 @@ With the help of Minecraft command system, MCDR can send Minecraft commands via 
 
 That's it, you can even think of MCDR as a robot that stares at the server console and can quickly respond to server output and input related commands if you like
 
-Plugin
-------
+## Plugin
 
 [Here](https://github.com/MCDReforged/PluginCatalogue) is a MCDR plugin collection repository
 
-Document
---------
+## Document
 
 Check <https://mcdreforged.readthedocs.io/> for more details of MCDR

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,4 +1,5 @@
-# MCDReforged
+MCDReforged
+===========
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
 [![PyPI Version](https://img.shields.io/pypi/v/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
@@ -19,13 +20,15 @@ MCDReforged（以下简称 MCDR）是一个可以在完全不对 Minecraft 服�
 
 QQ 群: [1101314858](https://jq.qq.com/?k=5gUuw9A)
 
-## 优势
+优势
+----
 
 - 运行于服务端之上，完全不需要修改服务端，保留原汁原味的原版特性
 - 可热重载的插件系统，无需重启服务端即可更新插件
 - 多平台/服务端的兼容性，支持在 Linux / Windows 下运行 vanilla、paper 以及 bungeecord 等服务端
 
-## 它是如何工作的？
+它是如何工作的？
+-------------
 
 MCDR 使用了 [Popen](https://docs.python.org/zh-cn/3/library/subprocess.html#subprocess.Popen) 来将服务端作为一个子进程启动，因此它便拥有了控制服务端标准输入/输出流的能力
 
@@ -35,11 +38,13 @@ Minecraft 服务器的控制台输出拥有着稳定的输出格式，并包含�
 
 就这样！如果你愿意的话，你可以将 MCDR 视为一个盯着服务端控制台看的，可以根据服务端的输出快速地做出响应并向服务端输入相关指令的，一个机器人
 
-## 插件
+插件
+----
 
 [这里](https://github.com/MCDReforged/PluginCatalogue) 是一个 MCDR 的插件收集仓库
 
-## 文档
+文档
+----
 
 想要了解更多关于 MCDR 的详情？去看文档吧
 <https://mcdreforged.readthedocs.io/zh_CN/latest/>

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,5 +1,4 @@
-MCDReforged
-===========
+# MCDReforged
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
 [![PyPI Version](https://img.shields.io/pypi/v/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
@@ -20,15 +19,13 @@ MCDReforged（以下简称 MCDR）是一个可以在完全不对 Minecraft 服�
 
 QQ 群: [1101314858](https://jq.qq.com/?k=5gUuw9A)
 
-优势
-----
+## 优势
 
 - 运行于服务端之上，完全不需要修改服务端，保留原汁原味的原版特性
 - 可热重载的插件系统，无需重启服务端即可更新插件
 - 多平台/服务端的兼容性，支持在 Linux / Windows 下运行 vanilla、paper 以及 bungeecord 等服务端
 
-它是如何工作的？
--------------
+## 它是如何工作的？
 
 MCDR 使用了 [Popen](https://docs.python.org/zh-cn/3/library/subprocess.html#subprocess.Popen) 来将服务端作为一个子进程启动，因此它便拥有了控制服务端标准输入/输出流的能力
 
@@ -38,13 +35,11 @@ Minecraft 服务器的控制台输出拥有着稳定的输出格式，并包含�
 
 就这样！如果你愿意的话，你可以将 MCDR 视为一个盯着服务端控制台看的，可以根据服务端的输出快速地做出响应并向服务端输入相关指令的，一个机器人
 
-插件
-----
+## 插件
 
 [这里](https://github.com/MCDReforged/PluginCatalogue) 是一个 MCDR 的插件收集仓库
 
-文档
-----
+## 文档
 
 想要了解更多关于 MCDR 的详情？去看文档吧
 <https://mcdreforged.readthedocs.io/zh_CN/latest/>

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,5 +1,4 @@
-MCDReforged
---------
+# MCDReforged
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
 [![PyPI Version](https://img.shields.io/pypi/v/mcdreforged.svg)](https://pypi.org/project/mcdreforged)
@@ -42,4 +41,5 @@ Minecraft 服务器的控制台输出拥有着稳定的输出格式，并包含�
 
 ## 文档
 
-想要了解更多关于 MCDR 的详情？去看文档吧 https://mcdreforged.readthedocs.io/zh_CN/latest/
+想要了解更多关于 MCDR 的详情？去看文档吧
+<https://mcdreforged.readthedocs.io/zh_CN/latest/>


### PR DESCRIPTION
# @markdownlint

一份符合 [Markdownlint **v0.23.1**](https://github.com/DavidAnson/markdownlint/tree/v0.23.1 "Markdown lint tool") 的 README
（并且不影响渲染效果）

### 包括

- [`MD009`](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md009---trailing-spaces "Trailing spaces") 去除多余的行尾空格
- [`MD034`](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md034---bare-url-used "Bare URL used") 将裸 URL 用尖括号包裹起来
- [`MD041`](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md041---first-line-in-a-file-should-be-a-top-level-heading "First line in a file should be a top-level heading") 标准的 Markdown 一级标题

> ~~[**fu哩姐姐**](https://github.com/Fallen-Breath "Fallen_Breath")嘶哈嘶哈嘶哈prprpr诶嘿嘿（逃~~
