### PR TITLE
Update Dependent Library Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ruamel.yaml~=0.17.16
-requests~=2.26.0
+requests~=2.27.0
 colorlog>=6.4
 colorama>=0.4.4
 psutil>=5.8.0


### PR DESCRIPTION
在装有最新版`requests`库的系统中启动`MCDR`将报出插件依赖项不存在的报错
`requests`库最新版本为`2.27.1`，在更新`requests`库时被提示`mcdreforged`不兼容

![Snipaste_2022-02-20_16-37-08](https://user-images.githubusercontent.com/64892985/154839808-0fd171eb-39ba-46c5-9c1e-84ced1db9b6a.png)
