### PR TITLE
Refactor(CI): Reusable workflows which fit Unix Philosophy

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -1,0 +1,29 @@
+name: Assemble a Dev Source Compressed File
+
+on: workflow_call
+
+jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    name: Assemble a dev source compressed file
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Dev Build
+        run: |
+          mkdir MCDReforged
+          mv * MCDReforged || true
+          cd MCDReforged
+          rm -rf .git tests
+          rm -f .gitignore logo_long.png setup.py MANIFEST.in *.md
+          mkdir server
+          mkdir config
+          rm -f plugins/*
+          rm -rf docs docs_prev
+          cd ..
+          zip -r MCDReforged-dev.zip ./MCDReforged
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: MCDReforged dev source for ${{ github.sha }}
+          path: MCDReforged-dev.zip

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,66 +10,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
-    name: Test with python ${{ matrix.python-version }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Test with pytest
-        run: |
-          pip install pytest
-          pip install pytest-cov
-          pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+    uses: ./.github/workflows/test.yml
 
   assemble:
-    runs-on: ubuntu-latest
-    name: Assemble a dev source compressed file
     needs: test
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Create Dev Build
-      run: |
-        mkdir MCDReforged
-        mv * MCDReforged || true
-        cd MCDReforged
-        rm -rf .git tests
-        rm -f .gitignore logo_long.png setup.py MANIFEST.in *.md
-        mkdir server
-        mkdir config
-        rm -f plugins/*
-        rm -rf docs docs_prev
-        cd ..
-        zip -r MCDReforged-dev.zip ./MCDReforged
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: MCDReforged dev source for ${{ github.sha }}
-        path: MCDReforged-dev.zip
+    uses: ./.github/workflows/assemble.yml
 
   pypi-upload:
     runs-on: ubuntu-latest
-    name: Make and upload a package to (test) pypi
+    name: Make and upload a package to (Test)PyPI
     needs: test
     if: github.event_name == 'push'
 
@@ -96,7 +45,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
 
-    - name: Publish distribution to Test PyPI
+    - name: Publish distribution to TestPyPI
       if: github.event_name == 'push'
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,59 +5,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
-    name: Test with python ${{ matrix.python-version }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Test with pytest
-        run: |
-          pip install pytest
-          pip install pytest-cov
-          pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+    uses: ./.github/workflows/test.yml
 
   assemble:
-    runs-on: ubuntu-latest
-    name: Assemble a dev source compressed file
     needs: test
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Create Dev Build
-      run: |
-        mkdir MCDReforged
-        mv * MCDReforged || true
-        cd MCDReforged
-        rm -rf .git tests
-        rm -f .gitignore logo_long.png setup.py MANIFEST.in *.md
-        mkdir server
-        mkdir config
-        rm -f plugins/*
-        rm -rf docs docs_prev
-        cd ..
-        zip -r MCDReforged-dev.zip ./MCDReforged
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: MCDReforged dev source for ${{ github.sha }}
-        path: MCDReforged-dev.zip
+    uses: ./.github/workflows/assemble.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test with Active Python Versions
+
+on: workflow_call
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+    name: Test with python ${{ matrix.python-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html


### PR DESCRIPTION
<!--狐狸姐姐斯哈斯哈prpr嘶溜嘶溜诶嘿嘿-->
> 符合**UNIX哲学**的可复用工作流

## 修改

- 重构 `.github/workflows/` 目录下的工作流，提高可复用性
  - 将重复的 `jobs` 提取到单独的工作流中
  - 在实际运行的工作流中通过 `workflow_call` 调用

- 修正少许拼写问题

### 参考
- [UNIX哲学](https://zh.wikipedia.org/wiki/Unix%E5%93%B2%E5%AD%A6)
- [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
