### PR TITLE
Supported PEP-561 for type hinting tools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
 	python_requires=REQUIRES_PYTHON,
 	url=URL,
 	packages=find_packages(exclude=['tests', '*.tests', '*.tests.*', 'tests.*']),
+	package_data={core_constant.PACKAGE_NAME: ["py.typed"]},
 	install_requires=REQUIRED,
 	include_package_data=True,
 	classifiers=CLASSIFIERS,


### PR DESCRIPTION
According to [PEP561](https://peps.python.org/pep-0561/), when exporting a package, a `py.typed` file should be provided in order to indicate that there are type annotations in the package. In this way, the static type checker(such as `mypy`) will recognize the types in `mcdreforged` package and perform better type checking work when developers coding their plugins.