### PR TITLE
[doc] Implement Algolia Docsearch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,19 @@ def setup(app):
 #
 html_theme = 'sphinx_rtd_theme'
 
+html_static_path = ['../static']
+
+html_css_files = [
+	'css/theme_overrides.css',  # override wide tables in RTD theme
+	'css/algolia.css',
+	'https://cdn.jsdelivr.net/npm/@docsearch/css@3'
+]
+
+html_js_files = [
+  ('https://cdn.jsdelivr.net/npm/@docsearch/js@3', {'defer': 'defer'}),
+  ('js/algolia.js', {'defer': 'defer'})
+]
+
 
 # Show a deeper toctree in the sidebar
 # https://stackoverflow.com/questions/27669376/show-entire-toctree-in-read-the-docs-sidebar
@@ -115,11 +128,3 @@ def autodoc_setup(app):
 	app.connect('autodoc-skip-member', autodoc_skip_member_handler)
 
 
-# -- save the table width ----------------------------------------------------
-# https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
-
-html_static_path = ['../static']
-
-html_css_files = [
-	'css/theme_overrides.css',  # override wide tables in RTD theme
-]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,12 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['../static']
 
 html_css_files = [
-	'css/theme_overrides.css',  # override wide tables in RTD theme
+	# override wide tables in RTD theme
+	# https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
+	'css/theme_overrides.css',  
+
+	# Algolia Docsearch
+	# https://docsearch.algolia.com/docs/DocSearch-v3
 	'css/algolia.css',
 	'https://cdn.jsdelivr.net/npm/@docsearch/css@3'
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,6 +69,7 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['../static']
 
 html_css_files = [
+	# Save the table width
 	# override wide tables in RTD theme
 	# https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
 	'css/theme_overrides.css',  

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,8 +81,8 @@ html_css_files = [
 ]
 
 html_js_files = [
-  ('https://cdn.jsdelivr.net/npm/@docsearch/js@3', {'defer': 'defer'}),
-  ('js/algolia.js', {'defer': 'defer'})
+	('https://cdn.jsdelivr.net/npm/@docsearch/js@3', {'defer': 'defer'}),
+	('js/algolia.js', {'defer': 'defer'})
 ]
 
 

--- a/docs/static/css/algolia.css
+++ b/docs/static/css/algolia.css
@@ -22,7 +22,7 @@
 }
 
 /* Gray algolia logo */
-.DocSearch-Logo {
+.DocSearch-Logo > svg {
     filter: grayscale(1) brightness(2);
 }
 

--- a/docs/static/css/algolia.css
+++ b/docs/static/css/algolia.css
@@ -22,7 +22,7 @@
 }
 
 /* Gray algolia logo */
-.DocSearch-Logo > svg {
+.DocSearch-Logo svg {
     filter: grayscale(1) brightness(2);
 }
 

--- a/docs/static/css/algolia.css
+++ b/docs/static/css/algolia.css
@@ -1,0 +1,37 @@
+/* --- Algolia Docsearch Styles --- */
+
+.wy-nav-side {
+    overflow: visible;
+}
+
+.wy-side-scroll {
+    overflow: inherit;
+}
+
+/* Override sphinx theme styles */
+.DocSearch-Input {
+    border: none !important;
+    box-shadow: none !important;
+    font-size: 1.2em !important;
+    padding: 0 0 0 8px !important;
+}
+
+.DocSearch-Button {
+    width: 100% !important;
+    margin: 0 !important;
+}
+
+/* Gray algolia logo */
+.DocSearch-Logo {
+    filter: grayscale(1) brightness(2);
+}
+
+/* Switchgear */
+#rtd-search-form > a {
+    color: #a5c0cf !important;
+    font-size: 0.5em;
+}
+
+#rtd-search-form > a:hover {
+    color: white !important;
+}

--- a/docs/static/css/algolia.css
+++ b/docs/static/css/algolia.css
@@ -1,5 +1,7 @@
 /* --- Algolia Docsearch Styles --- */
 
+/* Some sphinx ajustment */
+/* https://github.com/readthedocs/sphinx_rtd_theme/issues/761 */
 .wy-nav-side {
     overflow: visible;
 }
@@ -8,7 +10,7 @@
     overflow: inherit;
 }
 
-/* Override sphinx theme styles */
+/* Override sphinx theme styles for search box */
 .DocSearch-Input {
     border: none !important;
     box-shadow: none !important;
@@ -16,17 +18,13 @@
     padding: 0 0 0 8px !important;
 }
 
+/* Match sphinx width */
 .DocSearch-Button {
     width: 100% !important;
     margin: 0 !important;
 }
 
-/* Gray algolia logo */
-.DocSearch-Logo svg {
-    filter: grayscale(1) brightness(2);
-}
-
-/* Switchgear */
+/* Switchgear styles */
 #rtd-search-form > a {
     color: #a5c0cf !important;
     font-size: 0.5em;

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -1,0 +1,87 @@
+const translations = {
+  placeholder: '\u641c\u7d22\u6587\u6863',
+  button: {
+    buttonText: '\u641c\u7d22',
+    buttonAriaLabel: '\u641c\u7d22',
+  },
+  modal: {
+    searchBox: {
+      resetButtonTitle: '\u6e05\u9664\u641c\u7d22\u5185\u5bb9',
+      resetButtonAriaLabel: '\u6e05\u9664\u641c\u7d22\u5185\u5bb9',
+      cancelButtonText: '\u53d6\u6d88',
+      cancelButtonAriaLabel: '\u53d6\u6d88',
+    },
+    startScreen: {
+      recentSearchesTitle: '\u6700\u8fd1\u641c\u7d22',
+      noRecentSearchesText: '\u65e0\u6700\u8fd1\u641c\u7d22',
+      saveRecentSearchButtonTitle: '\u4fdd\u5b58\u641c\u7d22\u7ed3\u679c',
+      removeRecentSearchButtonTitle: '\u4ece\u5386\u53f2\u4e2d\u5220\u9664',
+      favoriteSearchesTitle: '\u6536\u85cf',
+      removeFavoriteSearchButtonTitle: '\u4ece\u6536\u85cf\u5939\u4e2d\u5220\u9664'
+    },
+    errorScreen: {
+      titleText: '\u65e0\u6cd5\u83b7\u53d6\u7ed3\u679c',
+      helpText: '\u68c0\u67e5\u7f51\u7edc\u8fde\u63a5'
+    },
+    footer: {
+      selectText: '\u9009\u62e9',
+      selectKeyAriaLabel: '\u56de\u8f66\u952e',
+      navigateText: '\u5bfc\u822a',
+      navigateUpKeyAriaLabel: '\u5411\u4e0a\u7bad\u5934',
+      navigateDownKeyAriaLabel: '\u5411\u4e0b\u7bad\u5934',
+      closeText: '\u5173\u95ed',
+      closeKeyAriaLabel: 'ESC',
+      searchByText: '\u91c7\u7528',
+    }
+  },
+};
+
+// Get current langeage
+if (typeof READTHEDOCS_DATA !== 'undefined') {
+  language = READTHEDOCS_DATA.language
+} else {
+  language = document.documentElement.lang
+}
+
+config = {
+  appId: 'A1XIV9INYQ',
+  apiKey: '43120950d3053488e5146d70643f567f', // public apiKey
+  indexName: 'mcdreforgeddocs', // en_US by default
+  container: '#rtd-search-form',
+  debug: false
+}
+
+// Set translations
+if (language.startsWith("zh")) {
+  config.translations = translations;
+  config.indexName = 'mcdreforgeddocs-zh_CN';
+  config.placeholder = translations.placeholder;
+  translations.switchgear = {
+    enable: '\u4f7f\u7528 Algolia Docsearch',
+    disable: '\u4f7f\u7528\u4f20\u7edf\u641c\u7d22\u65b9\u5f0f'
+  }
+} else {
+  translations.switchgear = {
+    enable: 'Use Algolia Docsearch',
+    disable: 'Use Legacy Search'
+  }
+};
+
+// Switchgear
+algolia_enabled = !document.cookie.includes('algolia=false')
+
+if (algolia_enabled) {
+  docsearch(config);
+}
+
+switchgear = document.createElement('a')
+switchgear.innerText = algolia_enabled ? translations.switchgear.disable : translations.switchgear.enable
+switchgear.onclick = function () {
+  if (algolia_enabled) {
+    document.cookie = 'algolia=false'
+  } else {
+    document.cookie = 'algolia=true'
+  }
+  location.reload()
+}
+document.getElementById('rtd-search-form').append(switchgear)

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -2,39 +2,39 @@
 // https://docsearch.algolia.com/docs/api
 
 const translations = {
-  placeholder: '\u641c\u7d22\u6587\u6863',
+  placeholder: '搜索文档',
   button: {
-    buttonText: '\u641c\u7d22',
-    buttonAriaLabel: '\u641c\u7d22',
+    buttonText: '搜索',
+    buttonAriaLabel: '搜索',
   },
   modal: {
     searchBox: {
-      resetButtonTitle: '\u6e05\u9664\u641c\u7d22\u5185\u5bb9',
-      resetButtonAriaLabel: '\u6e05\u9664\u641c\u7d22\u5185\u5bb9',
-      cancelButtonText: '\u53d6\u6d88',
-      cancelButtonAriaLabel: '\u53d6\u6d88',
+      resetButtonTitle: '清除搜索内容',
+      resetButtonAriaLabel: '清除搜索内容',
+      cancelButtonText: '取消',
+      cancelButtonAriaLabel: '取消',
     },
     startScreen: {
-      recentSearchesTitle: '\u6700\u8fd1\u641c\u7d22',
-      noRecentSearchesText: '\u65e0\u6700\u8fd1\u641c\u7d22',
-      saveRecentSearchButtonTitle: '\u4fdd\u5b58\u641c\u7d22\u7ed3\u679c',
-      removeRecentSearchButtonTitle: '\u4ece\u5386\u53f2\u4e2d\u5220\u9664',
-      favoriteSearchesTitle: '\u6536\u85cf',
-      removeFavoriteSearchButtonTitle: '\u4ece\u6536\u85cf\u5939\u4e2d\u5220\u9664'
+      recentSearchesTitle: '最近搜索',
+      noRecentSearchesText: '无最近搜索',
+      saveRecentSearchButtonTitle: '保存搜索结果',
+      removeRecentSearchButtonTitle: '从历史中删除',
+      favoriteSearchesTitle: '收藏',
+      removeFavoriteSearchButtonTitle: '从收藏夹中删除'
     },
     errorScreen: {
-      titleText: '\u65e0\u6cd5\u83b7\u53d6\u7ed3\u679c',
-      helpText: '\u68c0\u67e5\u7f51\u7edc\u8fde\u63a5'
+      titleText: '无法获取结果',
+      helpText: '检查网络连接'
     },
     footer: {
-      selectText: '\u9009\u62e9',
-      selectKeyAriaLabel: '\u56de\u8f66\u952e',
-      navigateText: '\u5bfc\u822a',
-      navigateUpKeyAriaLabel: '\u5411\u4e0a\u7bad\u5934',
-      navigateDownKeyAriaLabel: '\u5411\u4e0b\u7bad\u5934',
-      closeText: '\u5173\u95ed',
+      selectText: '选择',
+      selectKeyAriaLabel: '回车键',
+      navigateText: '导航',
+      navigateUpKeyAriaLabel: '向上箭头',
+      navigateDownKeyAriaLabel: '向下箭头',
+      closeText: '关闭',
       closeKeyAriaLabel: 'ESC',
-      searchByText: '\u91c7\u7528',
+      searchByText: '采用',
     }
   },
 };
@@ -60,8 +60,8 @@ if (language.startsWith("zh")) {
   config.indexName = 'mcdreforgeddocs-zh_CN';
   config.placeholder = translations.placeholder;
   translations.switchgear = {
-    enable: '\u4f7f\u7528 Algolia Docsearch',
-    disable: '\u4f7f\u7528\u4f20\u7edf\u641c\u7d22\u65b9\u5f0f'
+    enable: '使用 Algolia Docsearch',
+    disable: '使用传统搜索方式'
   }
 } else {
   translations.switchgear = {

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -68,20 +68,20 @@ if (language.startsWith("zh")) {
 };
 
 // Switchgear
-algolia_enabled = !document.cookie.includes('algolia=false')
+algolia_enabled = !document.cookie.includes('algolia=false');
 
 if (algolia_enabled) {
   docsearch(config);
 }
 
-switchgear = document.createElement('a')
-switchgear.innerText = algolia_enabled ? translations.switchgear.disable : translations.switchgear.enable
+switchgear = document.createElement('a');
+switchgear.innerText = algolia_enabled ? translations.switchgear.disable : translations.switchgear.enable;
 switchgear.onclick = function () {
   if (algolia_enabled) {
-    document.cookie = 'algolia=false'
+    document.cookie = 'algolia=false';
   } else {
-    document.cookie = 'algolia=true'
+    document.cookie = 'algolia=true';
   }
-  location.reload()
+  location.reload();
 }
-document.getElementById('rtd-search-form').append(switchgear)
+document.getElementById('rtd-search-form').append(switchgear);

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -1,7 +1,18 @@
 // Algolia Docsearch implement
 // https://docsearch.algolia.com/docs/api
 
-const translations = {
+const switchgear_i18n = {
+  en: {
+    enable: 'Use Algolia Docsearch',
+    disable: 'Use Legacy Search'
+  },
+  zh: {
+    enable: '使用 Algolia Docsearch',
+    disable: '使用传统搜索方式'
+  }
+}
+
+const algolia_i18n = {
   placeholder: '搜索文档',
   button: {
     buttonText: '搜索',
@@ -35,7 +46,13 @@ const translations = {
       closeText: '关闭',
       closeKeyAriaLabel: 'ESC',
       searchByText: '采用',
-    }
+    },
+    noResultsScreen: {
+      noResultsText: '没有关于此关键字的结果:',
+      suggestedQueryText: '试试搜索',
+      reportMissingResultsText: '文档中存在包含此关键字的内容？',
+      reportMissingResultsLinkText: '告诉我们',
+    },
   },
 };
 
@@ -56,19 +73,13 @@ if (typeof READTHEDOCS_DATA !== 'undefined') {
 
 // Set translations
 if (language.startsWith("zh")) {
-  config.translations = translations;
+  config.translations = algolia_i18n;
   config.indexName = 'mcdreforgeddocs-zh_CN';
-  config.placeholder = translations.placeholder;
-  translations.switchgear = {
-    enable: '使用 Algolia Docsearch',
-    disable: '使用传统搜索方式'
-  }
+  config.placeholder = algolia_i18n.placeholder;
+  switchgear_tr = switchgear_i18n.zh;
 } else {
-  translations.switchgear = {
-    enable: 'Use Algolia Docsearch',
-    disable: 'Use Legacy Search'
-  }
-};
+  switchgear_tr = switchgear_i18n.en;
+}
 
 // Switchgear
 // add a switchgear to allow users to still use the original search system
@@ -79,7 +90,7 @@ if (algolia_enabled) {
 }
 
 switchgear = document.createElement('a');
-switchgear.innerText = algolia_enabled ? translations.switchgear.disable : translations.switchgear.enable;
+switchgear.innerText = algolia_enabled ? switchgear_tr.disable : switchgear_tr.enable;
 switchgear.onclick = function () {
   if (algolia_enabled) {
     document.cookie = 'algolia=false';

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -47,7 +47,7 @@ config = {
   debug: false
 }
 
-// Get current langeage
+// Get current language
 if (typeof READTHEDOCS_DATA !== 'undefined') {
   language = READTHEDOCS_DATA.language
 } else {

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -1,3 +1,6 @@
+// Algolia Docsearch implement
+// https://docsearch.algolia.com/docs/api
+
 const translations = {
   placeholder: '\u641c\u7d22\u6587\u6863',
   button: {
@@ -36,19 +39,19 @@ const translations = {
   },
 };
 
-// Get current langeage
-if (typeof READTHEDOCS_DATA !== 'undefined') {
-  language = READTHEDOCS_DATA.language
-} else {
-  language = document.documentElement.lang
-}
-
 config = {
   appId: 'A1XIV9INYQ',
   apiKey: '43120950d3053488e5146d70643f567f', // public apiKey
   indexName: 'mcdreforgeddocs', // en_US by default
   container: '#rtd-search-form',
   debug: false
+}
+
+// Get current langeage
+if (typeof READTHEDOCS_DATA !== 'undefined') {
+  language = READTHEDOCS_DATA.language
+} else {
+  language = document.documentElement.lang
 }
 
 // Set translations
@@ -68,6 +71,7 @@ if (language.startsWith("zh")) {
 };
 
 // Switchgear
+// add a switchgear to allow users to still use the original search system
 algolia_enabled = !document.cookie.includes('algolia=false');
 
 if (algolia_enabled) {


### PR DESCRIPTION
## Why?
As I mentioned in #230, the current documentation search system is not convenient.

## What?
[Algolia Docsearch](https://docsearch.algolia.com) is a popular search system used by many OSS documentations. Searching with Algolia is safe, easy and fast.

## How?
As you can see, it's not difficult. We import the required js and css, and we call the `docsearch` method to replace the original search box with Algolia Docsearch.

I did some extra work to make it better, adding Chinese translations and a toggle button to allow users to still use the original search system.

## Preview
You can see a live preview [here](https://mcdreforgedtest.readthedocs.io/zh_CN/latest/).

## What's in the background?
An [Algolia Crawler](https://www.algolia.com/products/search-and-discovery/crawler/) helps us index the documentation. It would automatically visit both the English and Chinese documentation and crawl the content into 2 indexes called `mcdreforgeddocs` and `mcdreforgeddocs-zh_CN`.

When the page loading, we detect which language of documentation the user is visiting and provide the correct index and translation.

### The crwaler settings
I wrote the following [`recordExtractor`](https://docsearch.algolia.com/docs/record-extractor/) to crawl the documentation:
```
recordExtractor: ({$, helpers}) => {
    [".viewcode-link", ".headerlink"].forEach((e) => $(e).remove());
    return helpers.docsearch({
      recordProps: {
        lvl1: [".document h1"],
        content: [".document p, .document li"],
        lvl0: {
          selectors: [".breadcrumb-item a", ".breadcrumb-item"],
          defaultValue: "Documentation",
        },
        lvl2: [".document h2"],
        lvl3: [".document h3", ".document dt"],
        lvl4: [".document h4"],
        lvl5: [".document h5"],
        lvl6: [".document h6"],
      },
      aggregateContent: true,
      recordVersion: "v3",
    });
```
- `.viewcode-link` and `.headerlink` are removed to avoid placeholders appearing in indexes
- `.document` ensures that the content being indexed is taken from the real documentation
- `dt` ensures that contents in `Code References` being indexed correctly
- `lvl0` taken from breadcrumb makes that the indexes have a clear root

After testing, I believe that this crawler indexes the entire document correctly.

### The owner of the Algolia application
The real owner is always "Docsearch" itself. So if I understand correctly, I can invite anyone to the team and they will have the exactly same permissions as me.
![image](https://user-images.githubusercontent.com/45303195/222904015-0fdc77f4-f64b-4281-a3bd-73914b87d30c.png) ![image](https://user-images.githubusercontent.com/45303195/222904213-e4ff5328-230a-492a-bfa4-0032e62f39da.png)