### PR TITLE
[doc] Fix a css property that causes the nav side fail to scroll

### DIFF
--- a/docs/static/css/algolia.css
+++ b/docs/static/css/algolia.css
@@ -6,10 +6,6 @@
     overflow: visible;
 }
 
-.wy-side-scroll {
-    overflow: inherit;
-}
-
 /* Override sphinx theme styles for search box */
 .DocSearch-Input {
     border: none !important;


### PR DESCRIPTION
We seem to have introduced a wrong css property. After my testing, remove this does not cause other problems.